### PR TITLE
Adjust to the hardware change

### DIFF
--- a/src/epd/ch32v00x-drv.c
+++ b/src/epd/ch32v00x-drv.c
@@ -4,6 +4,7 @@
 
 #include "uc8253.h"
 #include "drv.h"
+#include "../mcu/debug.h"
 
 #define EPD_BUSY_PIN    GPIO_Pin_4 // pd4
 #define EPD_RST_PIN     GPIO_Pin_3 // pd3
@@ -63,7 +64,7 @@ void uc8253_init_hal()
 
 	// BUSY as input
 	iocfg.GPIO_Pin = EPD_BUSY_PIN;
-	iocfg.GPIO_Mode = GPIO_Mode_IPU;
+	iocfg.GPIO_Mode = GPIO_Mode_IPD;
 	GPIO_Init(GPIOD, &iocfg);
 
 	// CS as output

--- a/src/epd/uc8253.c
+++ b/src/epd/uc8253.c
@@ -75,6 +75,8 @@ void uc8253_send_blk(uint8_t *bytes, uint16_t len)
 
 void uc8253_cmd(uint8_t cmd)
 {
+	PRINT(__func__);
+	PRINT("\n");
 	uc8253_switch2cmd();
 
 	uc8253_select();
@@ -92,6 +94,8 @@ void uc8253_cmd_params(uint8_t *cmd_and_params, uint16_t len)
 // wating for BUSY pin to release
 static void wait(void)
 {
+	PRINT(__func__);
+	PRINT("\n");
 	if (uc8253_is_busy())
 		PRINT("epd> wating.. ");
 	else return;
@@ -101,7 +105,7 @@ static void wait(void)
 		// uc8253_cmd(GET_STATUS);
 		delay_ms(100);
 	}
-	PRINT("released.\n");
+	printf("released.\n");
 }
 
 /**
@@ -161,6 +165,8 @@ void uc8253_clear_mem(void)
 
 void uc8253_refresh_poll()
 {
+	PRINT(__func__);
+	PRINT("\n");
 	uc8253_cmd(DISPLAY_REFRESH);
 	wait();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,6 @@ int main(void)
 	uc8253_init();
 	uc8253_clear_mem();
 	// uc8253_refresh_poll();
-	PRINT("init done\n");
 
 	while (1) {
 		exe_cmd();

--- a/src/mcu/ch32v00x-hal.c
+++ b/src/mcu/ch32v00x-hal.c
@@ -49,17 +49,17 @@ static void spi_init()
 
 static void setup_GPO()
 {
-	RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOC, ENABLE);
+	RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOD, ENABLE);
 
 	GPIO_InitTypeDef p = {0};
-	p.GPIO_Pin = GPIO_Pin_3;
+	p.GPIO_Pin = GPIO_Pin_0; // changed to PD0 in the hardware
 	p.GPIO_Speed = GPIO_Speed_2MHz;
 	p.GPIO_Mode = GPIO_Mode_IPU;
-	GPIO_Init(GPIOC, &p);
+	GPIO_Init(GPIOD, &p);
 
-	GPIO_EXTILineConfig(GPIO_PortSourceGPIOC, 3);
+	GPIO_EXTILineConfig(GPIO_PortSourceGPIOD, 0);
 	EXTI_InitTypeDef ei = {0};
-	ei.EXTI_Line = EXTI_Line3;
+	ei.EXTI_Line = EXTI_Line0;
 	ei.EXTI_Mode = EXTI_Mode_Interrupt;
 	ei.EXTI_Trigger = EXTI_Trigger_Falling;
 	ei.EXTI_LineCmd = ENABLE;

--- a/src/nfc-tag/ch32v00x-drv.c
+++ b/src/nfc-tag/ch32v00x-drv.c
@@ -71,13 +71,13 @@ void EXTI7_0_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 void EXTI7_0_IRQHandler(void)
 {
 	__disable_irq();
-	if(EXTI_GetITStatus(EXTI_Line3))
+	if(EXTI_GetITStatus(EXTI_Line0))
 	{
 		printf("EXTI\n");
 		if (st25dv_has_rf_put_msg()) {
 			ntag_has_new_msg = 1;
 		}
-		EXTI_ClearITPendingBit(EXTI_Line3);
+		EXTI_ClearITPendingBit(EXTI_Line0);
 	}
 	__enable_irq();
 }


### PR DESCRIPTION
Fixes #11

## Summary by Sourcery

Adjust hardware-specific pin mappings and interrupt configurations for GPO, NFC, and EPD modules and enhance EPD controller routines with debug logging

Bug Fixes:
- Correct GPO pin assignment from PC3 to PD0 and update corresponding EXTI configuration
- Adjust NFC interrupt handler to monitor EXTI_Line0 instead of EXTI_Line3
- Change EPD busy pin input mode from pull-up to pull-down to match hardware

Enhancements:
- Add debug print traces to uc8253 command, wait, and refresh routines
- Include debug header in EPD driver
- Remove redundant startup print in main