### PR TITLE
fix: move the display's initial code to the app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,10 +158,10 @@ $(BUILD_DIR):
 #######################################
 WCH_OPENOCD = ../MRS_Toolchain_Linux_x64_V1.92/OpenOCD/bin/openocd
 program: $(BUILD_DIR)/$(TARGET).elf 
-	sudo $(WCH_OPENOCD) -f /home/kein-fedora/PROJECTS/jobs/fossasia/epaper-badge/ch32v003-nfc/MRS_Toolchain_Linux_x64_V1.92/OpenOCD/bin/wch-riscv.cfg -c init -c halt -c "program $^ verify 0x00000000 verify reset exit" -c exit
+	../MRS_Toolchain_Linux_x64_V1.92/OpenOCD/bin/wch-riscv.cfg -c init -c halt -c "program $^ verify 0x00000000 verify reset exit" -c exit
 
 wlink: $(BUILD_DIR)/$(TARGET).bin
-	sudo ../../wlink-linux-x64/wlink flash --address 0x08000000 $(BUILD_DIR)/$(TARGET).bin
+	wlink flash --address 0x08000000 $(BUILD_DIR)/$(TARGET).bin
 
 isp: $(BUILD_DIR)/$(TARGET).bin
 	wchisp flash $(BUILD_DIR)/$(TARGET).bin

--- a/src/epd/uc8253.c
+++ b/src/epd/uc8253.c
@@ -175,20 +175,4 @@ void uc8253_init() {
 	uc8253_init_hal();
 
 	reset();
-
-	// uc8253_cmd(BOOSTER_SOFT_START); // boost soft start
-	// uc8253_send(0xc7); // smoothest
-	// uc8253_send(0xc7); // smoothest
-	// uc8253_send(0xc7); // smoothest
-
-	uc8253_cmd(POWER_ON);
-	wait();
-
-	uc8253_cmd(PANEL_SETTING);
-	uc8253_send(0b11001111); // 480x240
-	uc8253_send(0x8D); // default
-
-	uc8253_cmd(VCOM_AND_DATA_INTERVAL_SETTING);
-	uc8253_send(0b11111111);
-	uc8253_send(0x0f);
 }


### PR DESCRIPTION
Fixes #13

## Summary by Sourcery

Remove embedded EPaper display initialization from the uc8253 driver and streamline flashing commands in the Makefile

Bug Fixes:
- Extract initial display setup logic from uc8253 driver to fix improper initialization (#13)

Build:
- Update Makefile to remove sudo usage and use direct OpenOCD and wlink tool paths for flashing